### PR TITLE
EOL issus windows-linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.sh text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,10 +3,9 @@
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
-*.sh text
 
-# Declare files that will always have CRLF line endings on checkout.
-*.sln text eol=lf
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary


### PR DESCRIPTION
Hi Berend,

I tried to get sim city -commonsense demo running on my Windows computer, but the docker-compose got stuck at the "build.sh".
Apparently, while cloning, git automatically changed the line endings from LF(Linux) to CRLF(Windows) and this caused the "build.sh" to be unreadable for docker-compose.  As this may be a common problem for Windows users,  I added a .gitattributes file to the repository that deals with this issue.

If you have any questions, ask me or Carlos. 

cheers,

Martine