### PR TITLE
eol and dependency issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 # Declare files that will always have LF line endings on checkout.
 *.sh text eol=lf
 run  text eol=lf
+gulpfile.js  text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -51,3 +51,9 @@ services:
       - webdav
       - simcity_webservice
       - commonsense
+    depends_on:
+      - db
+      - webdav
+      - simcity_webservice
+      - commonsense
+  


### PR DESCRIPTION
.gitattributes: added eol conversion also for gulpfile.js
NB: the .gitattributesfile is already present (and more elaborated) in the sim-city-cs and the csWeb repositories

docker-compose-demo.yml: added depends_on feature to create/start webservices in dependency order.
NB: this action may also be needed for the other docker compose files?